### PR TITLE
Update Hashalot Fee to get live fee from API

### DIFF
--- a/pools/hashalot.go
+++ b/pools/hashalot.go
@@ -54,5 +54,5 @@ func (p *Hashalot) GetName() string {
 }
 
 func (p *Hashalot) GetFee() float64 {
-	return 1.00
+	return 2.00
 }

--- a/pools/hashalot.go
+++ b/pools/hashalot.go
@@ -57,11 +57,11 @@ func (p *Hashalot) GetFee() float64 {
 	jsonPayload := map[string]interface{}{}
 	err := util.GetJson(fmt.Sprintf("http://api.hashalot.net/pools/"), &jsonPayload)
 	if err != nil {
-		return 0
+		return 2.0
 	}
 	fee, ok := jsonPayload[0]["poolFeePercent"].(float64)
 	if !ok {
-		return 0
+		return 2.0
 	}
 	return uint64(fee)
 }

--- a/pools/hashalot.go
+++ b/pools/hashalot.go
@@ -55,13 +55,25 @@ func (p *Hashalot) GetName() string {
 
 func (p *Hashalot) GetFee() float64 {
 	jsonPayload := map[string]interface{}{}
-	err := util.GetJson(fmt.Sprintf("http://api.hashalot.net/pools/"), &jsonPayload)
+	err := util.GetJson("http://api.hashalot.net/pools", &jsonPayload)
 	if err != nil {
 		return 2.0
 	}
-	fee, ok := jsonPayload[0]["poolFeePercent"].(float64)
+	
+	pools, ok := jsonPayload["pools"].([]interface{})
 	if !ok {
 		return 2.0
 	}
-	return uint64(fee)
+	
+	pool, ok := pools[0].(map[string]interface{})
+	if !ok {
+		return 2.0
+	}
+	
+	fee, ok := pool["poolFeePercent"].(float64)
+	if !ok {
+		return 2.0
+	}
+
+	return fee
 }

--- a/pools/hashalot.go
+++ b/pools/hashalot.go
@@ -54,5 +54,14 @@ func (p *Hashalot) GetName() string {
 }
 
 func (p *Hashalot) GetFee() float64 {
-	return 2.00
+	jsonPayload := map[string]interface{}{}
+	err := util.GetJson(fmt.Sprintf("http://api.hashalot.net/pools/"), &jsonPayload)
+	if err != nil {
+		return 0
+	}
+	fee, ok := jsonPayload[0]["poolFeePercent"].(float64)
+	if !ok {
+		return 0
+	}
+	return uint64(fee)
 }


### PR DESCRIPTION
Fee is available via API for Hashalot.net:

`https://api.hashalot.net/pools`

In case we can build that in (not familiar with go, unfortunately). Will be at:

`pools[0].poolFeePercent`

(pool[1] is the solo pool)