### PR TITLE
Add .net to Hashalot label to easily reference website

### DIFF
--- a/pools/hashalot.go
+++ b/pools/hashalot.go
@@ -50,7 +50,7 @@ func (p *Hashalot) GetID() int {
 }
 
 func (p *Hashalot) GetName() string {
-	return "Hashalot"
+	return "Hashalot.net"
 }
 
 func (p *Hashalot) GetFee() float64 {


### PR DESCRIPTION
In case the OCM user wants to reference the website address.