### PR TITLE
Update pending balance endpoint for Hashalot.net

### DIFF
--- a/pools/hashalot.go
+++ b/pools/hashalot.go
@@ -25,7 +25,7 @@ func (p *Hashalot) GetPendingPayout() uint64 {
 	if err != nil {
 		return 0
 	}
-	vtc, ok := jsonPayload["pendingBalance"].(float64)
+	vtc, ok := jsonPayload["balance"].(float64)
 	if !ok {
 		return 0
 	}


### PR DESCRIPTION
Pending balance endpoint undergoing maintenance.  Found a bug in calculations related to orphaned blocks.  Moving to balance endpoint in the meantime, which is the actual confirmed balance.