### PR TITLE
Move pool fee to it's own interval

### DIFF
--- a/frontend/src/components/Mining.vue
+++ b/frontend/src/components/Mining.vue
@@ -126,13 +126,15 @@ export default {
       window.backend.Backend.GetPoolName().then(result => {
         self.activePool = result;
       });
-      window.backend.Backend.GetPoolFee().then(result => {
-        self.poolFee = result;
-      });
       window.backend.Backend.Address().then(result => {
         self.address = result;
       });
     }, 5000);
+    window.setInterval(() => {
+      window.backend.Backend.GetPoolFee().then(result => {
+        self.poolFee = result;
+      });
+    }, 300000); 
     window.backend.Backend.GetPoolName().then(result => {
       self.activePool = result;
     });


### PR DESCRIPTION
Hashalot.net is the only pool that has the fee via an API, the others are statically set.  Move to it's own interval to avoid hitting Hashalot API with a new request every 5 seconds.  Fee will never change that often.