### PR TITLE
Remove API call, return static value

### DIFF
--- a/pools/hashalot.go
+++ b/pools/hashalot.go
@@ -25,7 +25,7 @@ func (p *Hashalot) GetPendingPayout() uint64 {
 	if err != nil {
 		return 0
 	}
-	vtc, ok := jsonPayload["balance"].(float64)
+	vtc, ok := jsonPayload["pendingBalance"].(float64)
 	if !ok {
 		return 0
 	}

--- a/pools/hashalot.go
+++ b/pools/hashalot.go
@@ -54,26 +54,5 @@ func (p *Hashalot) GetName() string {
 }
 
 func (p *Hashalot) GetFee() float64 {
-	jsonPayload := map[string]interface{}{}
-	err := util.GetJson("http://api.hashalot.net/pools", &jsonPayload)
-	if err != nil {
-		return 2.0
-	}
-	
-	pools, ok := jsonPayload["pools"].([]interface{})
-	if !ok {
-		return 2.0
-	}
-	
-	pool, ok := pools[0].(map[string]interface{})
-	if !ok {
-		return 2.0
-	}
-	
-	fee, ok := pool["poolFeePercent"].(float64)
-	if !ok {
-		return 2.0
-	}
-
-	return fee
+	return 2.0
 }

--- a/pools/hashalot.go
+++ b/pools/hashalot.go
@@ -25,7 +25,7 @@ func (p *Hashalot) GetPendingPayout() uint64 {
 	if err != nil {
 		return 0
 	}
-	vtc, ok := jsonPayload["pendingBalance"].(float64)
+	vtc, ok := jsonPayload["balance"].(float64)
 	if !ok {
 		return 0
 	}


### PR DESCRIPTION
After consideration, the fee will likely never change at this point and this will alleviate the 5 second API calls to the Hashalot API.