### PR TITLE
Remove P2Pool

### DIFF
--- a/pools/pool.go
+++ b/pools/pool.go
@@ -22,7 +22,7 @@ func GetPools(addr string, testnet bool) []Pool {
 		NewHashalot(addr),
 		NewZergpool(addr),
 		NewSuprnova(addr),
-		NewP2Pool(addr),
+		//NewP2Pool(addr),
 	}
 }
 


### PR DESCRIPTION
This pull request removes P2Pool from the pools list.  The current singular P2Pool node that OCM is connecting to is experiencing nearly 50% DOA hash rate due to being overloaded.  Currently this is near 100 MH/s which is being lost.  Removing P2Pool from pool.go sends upgrading users to the first pool in the list (Vertcoinpool) which currently has the lowest amount of hash rate compared to the remaining pools in OCM.  Users who wish to stay on P2Pool can choose to not upgrade or wait until there is a more suitable solution such as functionality for choosing which node to connect to based on ping, etc.