### PR TITLE
Automatically select the closest server to the miner.

### DIFF
--- a/pools/bbqdroid.go
+++ b/pools/bbqdroid.go
@@ -34,7 +34,7 @@ func (p *BBQDroid) GetPendingPayout() uint64 {
 }
 
 func (p *BBQDroid) GetStratumUrl() string {
-	return "stratum+tcp://bbqdroid.org:10001"
+	return "stratum+tcp://mining.bbqdroid.org:10001"
 }
 
 func (p *BBQDroid) GetUsername() string {


### PR DESCRIPTION
The pool has since added more servers in another region. This will allow the miner to automatically connect to the closest.