### PR TITLE
Update average earnings to account for VTC halvings

### DIFF
--- a/backend/mining.go
+++ b/backend/mining.go
@@ -78,6 +78,7 @@ func (m *Backend) StartMining() bool {
 	go func() {
 		cycles := 0
 		nhr := util.GetNetHash()
+		th := util.GetTipHeight()
 		continueLoop := true
 		for continueLoop {
 			cycles++
@@ -111,7 +112,14 @@ func (m *Backend) StartMining() bool {
 
 			m.runtime.Events.Emit("networkHashRate", fmt.Sprintf("%0.2f %s", netHash, hashrateUnit))
 
-			avgEarning := float64(hr) / float64(nhr) * float64(14400) // 14400 = Emission per day. Need to adjust for halving
+            var coinsPerDay float64
+            if th < 1680000 {
+                coinsPerDay = 14400 // Emission per day before halving at block 1680000
+            } else {
+                coinsPerDay = 7200 // Emission per day after halving at block 1680000
+            }
+
+            avgEarning := float64(hr) / float64(nhr) * float64(coinsPerDay)
 
 			m.runtime.Events.Emit("avgEarnings", fmt.Sprintf("%0.2f VTC", avgEarning))
 

--- a/util/util.go
+++ b/util/util.go
@@ -108,6 +108,13 @@ func GetDifficulty() float64 {
 	return info.Difficulty
 }
 
+func GetTipHeight() int64 {
+	info := getInfoResponse{}
+	url := fmt.Sprintf("%sinfo", networks.Active.OCMBackend)
+	GetJson(url, &info)
+	return info.TipHeight
+}
+
 func GetNetHash() uint64 {
 	difficulty := big.NewFloat(GetDifficulty())
 	factor := big.NewInt(0).Exp(big.NewInt(2), big.NewInt(48), nil)


### PR DESCRIPTION
This PR adjusts the amount of coins emitted per day in the average earnings calculation by pulling tipHeight from ocm-backend.