### PR TITLE
Bugfix - Skip p2pool nodes with 0ms ping time

### DIFF
--- a/ping/ping.go
+++ b/ping/ping.go
@@ -94,6 +94,9 @@ func selector() {
 			})
 
 			for i := 0; i < len(NodeList); i++ {
+				if NodeList[i].PingTime == 0 { // We need to skip nodes with a pingTime of 0ms, they're either not active or they're not responding to pings and OCM will select it if it responds to the following requests.
+					continue
+				}
 				nodeInformation, _ := GetNodeInformation(NodeList[i].URL)
 				fee := CheckFee(nodeInformation)
 				if fee {


### PR DESCRIPTION
This PR will introduce a simple check to see if p2pool nodes have a response time of 0ms. When introducing the ping functionality I falsely assumed that the nodes with 0ms ping time (Timeout), wouldn't respond to fee fetching and current miners' requests. 

This however, is not the case if the host ignores ICMP pings. This means OCM will always select the given node as long as the fee isn't above maxFee and the max miners per node aren't exceeded.