### PR TITLE
Temporarily remove p2pool node boofpool.ddns.net

### DIFF
--- a/p2pool_nodes.json
+++ b/p2pool_nodes.json
@@ -55,11 +55,6 @@
 		"URL":      "http://siberia.mine.nu:9171/"
 	},
 	{
-		"Hostname": "boofpool.ddns.net",
-		"Stratum":  "stratum+tcp://boofpool.ddns.net:9171",
-		"URL":      "http://boofpool.ddns.net:9171/"
-	},
-	{
 		"Hostname": "vtc-brn.webhop.me",
 		"Stratum":  "stratum+tcp://vtc-brn.webhop.me:9171",
 		"URL":      "http://vtc-brn.webhop.me:9171/"


### PR DESCRIPTION
This is the node referred to in PR #482.

Currently, this node gets all p2pool miners on the newest release. Miners are getting reduced mining rewards because of this atm.

This ought to be reverted once a new release addressing the bug is out.