### PR TITLE
Remove error message for local p2pool node

### DIFF
--- a/ping/ping.go
+++ b/ping/ping.go
@@ -153,7 +153,9 @@ func PingNodes(NodeList []Nodes) error {
 func GetNodeInformation(NodeURL string) (jsonPayload map[string]interface{}, err error) {
 	err = util.GetJson(fmt.Sprintf("%slocal_stats", NodeURL), &jsonPayload)
 	if err != nil {
+		if NodeURL != "http://127.0.0.1:9171/" {
 		logging.Errorf("Unable to fetch node information\n", err.Error())
+		}
 		return jsonPayload, err
 	}
 	return jsonPayload, nil


### PR DESCRIPTION
Some users find this error message confusing when they look at their debug.log. This PR removes that message.

The error message is largely redundant anyway.