### PR TITLE
New backend servers 

### DIFF
--- a/backend/checks.go
+++ b/backend/checks.go
@@ -2,12 +2,15 @@ package backend
 
 import (
 	"fmt"
+	"math/rand"
 	"path/filepath"
 	"runtime"
+	"time"
 
 	verthash "github.com/gertjaap/verthash-go"
 	"github.com/vertcoin-project/one-click-miner-vnext/logging"
 	"github.com/vertcoin-project/one-click-miner-vnext/miners"
+	"github.com/vertcoin-project/one-click-miner-vnext/networks"
 	"github.com/vertcoin-project/one-click-miner-vnext/tracking"
 	"github.com/vertcoin-project/one-click-miner-vnext/util"
 )
@@ -77,6 +80,10 @@ func (m *Backend) PerformChecks() string {
 		errorString := fmt.Sprintf("Failed to create or verify Verthash data file: %s", err.Error())
 		m.runtime.Events.Emit("checkStatus", "Failed")
 		return errorString
+	}
+
+	for networks.Active.OCMBackend == "" {
+		time.Sleep(500 * time.Millisecond)
 	}
 
 	args := m.GetArgs()
@@ -201,4 +208,31 @@ func (m *Backend) InstallMinerBinaries() error {
 		}
 	}
 	return nil
+}
+
+// Will be run at startup
+// Additionally it can be run if the backend returns an error after startup
+func (m *Backend) BackendServerSelector() {
+	// Pick a random backend off the list
+	rand.Seed(time.Now().UnixNano())
+	n := rand.Intn(len(networks.Active.BackendServers))
+
+	// Run a simple check to see if the backend is up and returned data isn't nonsense
+	// If the backend is bad, go through the list until a suitable one is found
+	for range networks.Active.BackendServers {
+		b := util.CheckBackendStatus(networks.Active.BackendServers[n])
+		if b {
+			// If backend is up and return data other than 0, save it in networks.Active
+			networks.Active.OCMBackend = networks.Active.BackendServers[n]
+			logging.Infof("Using backend: %s\n", networks.Active.OCMBackend)
+			return
+		}
+		n += 1
+		if n == len(networks.Active.BackendServers) {
+			n = 0
+		}
+	}
+	// We'll only ever get here if all backends are unreachable..
+	networks.Active.OCMBackend = networks.Active.BackendServers[0]
+	logging.Errorf("No working backend could be found..\n")
 }

--- a/main.go
+++ b/main.go
@@ -98,6 +98,7 @@ func main() {
 		panic(err)
 	}
 	networks.SetNetwork(backend.GetTestnet())
+	go backend.BackendServerSelector()
 	ping.GetSelectedNode(backend.GetTestnet())
 
 	backend.ResetPool()

--- a/networks/networks.go
+++ b/networks/networks.go
@@ -9,6 +9,7 @@ type Network struct {
 	P2ProxyURL         string
 	WalletDB           string
 	OCMBackend         string
+	BackendServers     []string
 }
 
 var Active Network
@@ -29,11 +30,13 @@ func SetNetwork(testnet bool) {
 			Base58P2PKHVersion: 71,
 			Base58P2SHVersion:  5,
 			InsightURL:         "https://insight.vertcoin.org/",
-			OCMBackend:         "https://ocm-backend.blkidx.org/",
 			Bech32Prefix:       "vtc",
 			P2ProxyStratum:     "stratum+tcp://p2proxy.vertcoin.org:9171",
 			P2ProxyURL:         "https://p2proxy.vertcoin.org/",
 			WalletDB:           "wallet-testnet.db",
+			BackendServers: []string{
+				"https://ocmbackend.javerity.com/",
+				"https://ocmbackend.mindcraftblocks.com/"},
 		}
 	}
 }

--- a/tracking/matomo.go
+++ b/tracking/matomo.go
@@ -73,7 +73,7 @@ func StartTracker() {
 			if !trackingEnabled {
 				continue
 			}
-			req, err := http.NewRequest("GET", "https://matomo.gertjaap.org/matomo.php", nil)
+			req, err := http.NewRequest("GET", "https://analytics.javerity.com/matomo.php", nil)
 			if err != nil {
 				log.Print(err)
 				os.Exit(1)

--- a/util/util.go
+++ b/util/util.go
@@ -84,6 +84,28 @@ type VerthashMinerDeviceConfig struct {
 	Platform    string
 }
 
+// Returns true if backend is good
+func CheckBackendStatus(backend string) bool {
+	info := getInfoResponse{}
+	url := fmt.Sprintf("%sinfo", backend)
+	err := GetJson(url, &info)
+	if err != nil {
+		logging.Errorf("Backend server failed to respond: %v", err)
+		return false
+	}
+	// If any of the following are 0, backend server has a problem
+	if info.BackendTipHeight == 0 {
+		return false
+	}
+	if info.TipHeight == 0 {
+		return false
+	}
+	if info.Difficulty == 0 {
+		return false
+	}
+	return true
+}
+
 func GetDifficulty() float64 {
 	info := getInfoResponse{}
 	url := fmt.Sprintf("%sinfo", networks.Active.OCMBackend)
@@ -115,7 +137,7 @@ func GetNetHash() uint64 {
 }
 
 func GetCoinsPerDay(th int64) float64 {
-	halvings := th / 840000	// Vertcoin undergoes a halving event every 840000 blocks
+	halvings := th / 840000 // Vertcoin undergoes a halving event every 840000 blocks
 
 	if halvings >= 32 { // Vertcoin will undergo 32 halvings before zero emission
 		return 0
@@ -125,7 +147,7 @@ func GetCoinsPerDay(th int64) float64 {
 	}
 
 	cpd := float64(28800)
-	
+
 	for i := int64(0); i < halvings; i++ {
 		cpd = cpd / 2
 	}


### PR DESCRIPTION
Replaced backend servers with 3 new backends.
At startup a random backend is picked, then a check is run to determine whether or not the backend is up and if the returned data is something other than zero. Previously backends has sometimes been reachable, but returned data has been 0.

If the backend is determined to be bad, the next backend in line goes through the same test, and so on. If by all odds all backends are bad, the first backend from the array is selected.

Additionally also replaced the matomo server.