### PR TITLE
Move pool fee api call to separate interval

### DIFF
--- a/frontend/src/components/Mining.vue
+++ b/frontend/src/components/Mining.vue
@@ -126,13 +126,15 @@ export default {
       window.backend.Backend.GetPoolName().then(result => {
         self.activePool = result;
       });
-      window.backend.Backend.GetPoolFee().then(result => {
-        self.poolFee = result;
-      });
       window.backend.Backend.Address().then(result => {
         self.address = result;
       });
     }, 5000);
+    window.setInterval(() => {
+      window.backend.Backend.GetPoolFee().then(result => {
+        self.poolFee = result;
+      });
+    }, 10 * 60 * 1000);
     window.backend.Backend.GetPoolName().then(result => {
       self.activePool = result;
     });


### PR DESCRIPTION
The current frontend update calls the backend `GetPoolFee()` every 5 seconds.  This results in a large influx of API calls to the pool API endpoint.

This PR moves the `GetPoolFee()` to it's own 10 minute interval.