### PR TITLE
Remove deprecated call to rand.Seed

### DIFF
--- a/backend/checks.go
+++ b/backend/checks.go
@@ -217,7 +217,6 @@ func (m *Backend) InstallMinerBinaries() error {
 // Additionally it can be run if the backend returns an error after startup
 func (m *Backend) BackendServerSelector() {
 	// Pick a random backend off the list
-	rand.Seed(time.Now().UnixNano())
 	n := rand.Intn(len(networks.Active.BackendServers))
 
 	// Run a simple check to see if the backend is up and returned data isn't nonsense

--- a/backend/settings.go
+++ b/backend/settings.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math/rand"
 	"strconv"
-	"time"
 
 	"github.com/tidwall/buntdb"
 	"github.com/vertcoin-project/one-click-miner-vnext/logging"
@@ -73,7 +72,6 @@ func (m *Backend) GetPool() int {
 			return 2 // Default P2Pool on testnet
 		}
 		// Default to a random pool
-		rand.Seed(time.Now().UnixNano())
 		pools := pools.GetPools(m.Address(), m.GetTestnet())
 		pool := pools[rand.Intn(len(pools))].GetID()
 		// Save this setting immediately so that we don't get

--- a/ping/ping.go
+++ b/ping/ping.go
@@ -81,7 +81,6 @@ func selector() {
 		err = PingNodes(NodeList)
 		if err != nil {
 			logging.Warnf("Nodes could not be pinged, selecting random node\n")
-			rand.Seed(time.Now().Unix())
 			randInt := rand.Intn(len(NodeList))
 			Selected = SelectedNode{
 				P2PoolStratum: NodeList[randInt].Stratum,


### PR DESCRIPTION
As of Go 1.20, seeding the random functions is no longer needed.